### PR TITLE
Remove DocumenterLaTeX from list of packages

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -13,7 +13,6 @@ JuliaDocs is the home for the following packages and repositories:
 * [Documenter -- Package to combine docstrings with Markdown pages for generating documentation](https://github.com/JuliaDocs/Documenter.jl)
 * [DocumenterCitations -- Support for BibTeX citations in Documenter](https://github.com/JuliaDocs/DocumenterCitations.jl)
 * [DocumenterMarkdown -- Documenter's Markdown / MkDocs backend](https://github.com/JuliaDocs/DocumenterMarkdown.jl)
-* [DocumenterLaTeX -- Documenter's LaTeX / PDF backend](https://github.com/JuliaDocs/DocumenterLaTeX.jl)
 * [DocumenterTools -- Extra tools for setting up Documenter](https://github.com/JuliaDocs/DocumenterTools.jl)
 * [DocStringExtensions -- Programmatic ways to generate parts of docstrings](https://github.com/JuliaDocs/DocStringExtensions.jl)
 * [Highlights -- A code highlighter for the Julia language, written in Julia](https://github.com/JuliaDocs/Highlights.jl)
@@ -51,15 +50,6 @@ PackageDefinition(
     ],
     [
         "https://codecov.io/gh/JuliaDocs/DocumenterMarkdown.jl/branch/master/graph/badge.svg" => "https://codecov.io/gh/JuliaDocs/DocumenterMarkdown.jl",
-    ]
-),
-PackageDefinition(
-    "DocumenterLaTeX", "https://github.com/JuliaDocs/DocumenterLaTeX.jl",
-    [
-        "README" => "https://github.com/JuliaDocs/DocumenterLaTeX.jl#documenterlatex",
-    ],
-    [
-        "https://codecov.io/gh/JuliaDocs/DocumenterLaTeX.jl/branch/master/graph/badge.svg" => "https://codecov.io/gh/JuliaDocs/DocumenterLaTeX.jl",
     ]
 ),
 PackageDefinition(


### PR DESCRIPTION
This package has been unmaintained and archived.

---

On the flipside there are a bunch of packages missing, e.g. [DocInventories.jl](https://github.com/JuliaDocs/DocInventories.jl) or [DocumenterMermaid.jl](https://github.com/JuliaDocs/DocumenterMermaid.jl) and several more... 

Perhaps it would be better to auto-generate the list via GH workflow that queries GitHub for a list of all repositories and their descriptions and "website URLs" (GitHub metadata) and based on that generate the bulk of the content of this page, skipping archive repositories and perhaps including an additional block list (to e.g. skip this repository)

(Or one step simpler: just a which does all that, but it is run manually by a user who can then post process it. It is not as if this needs to be run constantly, but surely once in a while.